### PR TITLE
refactor: make api more easy

### DIFF
--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,17 +1,14 @@
 import { useState } from 'react';
 import { useInfiniteFetch } from '../lib';
-import { postAdapter, postModel } from '../model';
+import { postAdapter, getPostList } from '../model';
 import type { PostLayout } from '../types';
 
 export function PostList() {
   const [layout, setLayout] = useState<PostLayout>('classic');
-  const { data, fetchNextPage } = useInfiniteFetch(
-    postModel.accessorGetters.getPostList({ layout }),
-    model => {
-      const key = JSON.stringify({ layout });
-      return postAdapter.getPagination(model, key);
-    }
-  );
+  const { data, fetchNextPage } = useInfiniteFetch(getPostList({ layout }), model => {
+    const key = JSON.stringify({ layout });
+    return postAdapter.getPagination(model, key);
+  });
 
   return (
     <div style={{ borderTop: '1px solid black', marginTop: '20px' }}>

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -1,4 +1,4 @@
-import { postModel } from '../model';
+import { getPostById } from '../model';
 import { useFetch } from '../lib';
 
 interface Props {
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export function usePost({ id }: Props) {
-  const { data } = useFetch(postModel.accessorGetters.getPostById(id), model => {
+  const { data } = useFetch(getPostById(id), model => {
     return model.data[id];
   });
 

--- a/src/lib/model/types.ts
+++ b/src/lib/model/types.ts
@@ -6,13 +6,11 @@ interface BaseAction<Arg, D> {
 }
 
 export interface NormalAction<Model, Arg = any, Data = any> extends BaseAction<Arg, Data> {
-  type: 'normal';
   fetchData: (arg: Arg) => Promise<Data>;
   syncModel: (model: Draft<Model>, payload: { data: Data; arg: Arg }) => void;
 }
 
 export interface InfiniteAction<Model, Arg = any, Data = any> extends BaseAction<Arg, Data[]> {
-  type: 'infinite';
   fetchData: (
     arg: Arg,
     meta: { previousData: Data | null; pageIndex: number }

--- a/src/model/postModel.ts
+++ b/src/model/postModel.ts
@@ -1,16 +1,15 @@
 import type { Post, PostLayout } from '../types';
-import type { Action } from '../lib';
-import { Model, createPaginationAdapter } from '../lib';
+import { createModel } from '../lib';
+import { createPaginationAdapter } from '../lib';
 import { getPostById as getPostByIdRequest, getPostList as getPostListRequest } from '../request';
 
 export const postAdapter = createPaginationAdapter<Post>({});
 const initialModel = postAdapter.initialModel;
 
-type PostModel = typeof initialModel;
+export const postModel = createModel(initialModel);
 
-const getPostById: Action<PostModel, number, Post> = {
-  type: 'normal',
-  fetchData: async id => {
+export const getPostById = postModel.defineNormalAction({
+  fetchData: async (id: number) => {
     const data = await getPostByIdRequest(id);
     return data;
   },
@@ -25,10 +24,9 @@ const getPostById: Action<PostModel, number, Post> = {
     console.log(`Success on getPostById with arg: ${arg}`);
     console.log(data);
   },
-};
+});
 
-const getPostList: Action<PostModel, { layout: PostLayout }, Post[]> = {
-  type: 'infinite',
+export const getPostList = postModel.defineInfiniteAction<{ layout: PostLayout }, Post[]>({
   fetchData: async ({ layout }, { pageIndex, previousData }) => {
     if (previousData?.length === 0) return null;
     const data = await getPostListRequest({ layout, page: pageIndex });
@@ -46,6 +44,4 @@ const getPostList: Action<PostModel, { layout: PostLayout }, Post[]> = {
     console.log(`Success on getPostList with arg: ${arg}`);
     console.log(data);
   },
-};
-
-export const postModel = new Model(initialModel, { getPostById, getPostList });
+});


### PR DESCRIPTION
This pr add `createModel` to make the api more easy to use.