### PR TITLE
feat: add readPagination to return items and meta

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,3 +17,4 @@ jobs:
           version: '8.5.1'
           run_install: true
       - run: pnpm test
+      - run: pnpm build-lib

--- a/src/__tests__/types.ts
+++ b/src/__tests__/types.ts
@@ -1,0 +1,7 @@
+export type PostLayout = 'classic' | 'image';
+
+export interface Post {
+  id: number;
+  title: string;
+  layout: PostLayout;
+}

--- a/src/example/components/PostList.tsx
+++ b/src/example/components/PostList.tsx
@@ -1,19 +1,17 @@
 import { useState } from 'react';
 import { useInfiniteFetch } from '../../lib';
-import { postAdapter, getPostList, postModel } from '../model';
+import { postAdapter, getPostList } from '../model';
 import type { PostLayout } from '../types';
 
 export function PostList() {
   const [layout, setLayout] = useState<PostLayout>('classic');
   const key = JSON.stringify({ layout });
   const { data, fetchNextPage } = useInfiniteFetch(getPostList({ layout }), model => {
-    return postAdapter.getPagination(model, key);
+    return postAdapter.readPagination(model, key);
   });
 
-  const paginationMeta = postAdapter.getPaginationMeta(postModel.getModel(), key);
-
   const loadMore = () => {
-    if (paginationMeta?.noMore) return;
+    if (data?.noMore) return;
     fetchNextPage();
   };
 
@@ -28,13 +26,15 @@ export function PostList() {
       >
         toggle layout
       </button>
-      <button onClick={loadMore} disabled={paginationMeta?.noMore}>
+      <button onClick={loadMore} disabled={data?.noMore}>
         fetch next page
       </button>
-      {data.map(post => {
+      {data?.items.map(post => {
         return (
           <div key={post.id}>
-            <div>title: {post.title}</div>
+            <div>
+              title: {post.title}, layout: {post.layout}
+            </div>
           </div>
         );
       })}

--- a/src/example/model/postModel.ts
+++ b/src/example/model/postModel.ts
@@ -34,7 +34,11 @@ export const getPostList = postModel.defineAction<{ layout: PostLayout }, Post[]
   },
   syncModel: (draft, { data, arg, pageIndex }) => {
     const paginationKey = JSON.stringify(arg);
-    postAdapter.updatePagination(draft, { data: data, paginationKey, pageIndex });
+    if (pageIndex === 0) {
+      postAdapter.replacePagination(draft, paginationKey, data);
+    } else {
+      postAdapter.appendPagination(draft, paginationKey, data);
+    }
   },
   onError: ({ error, arg }) => {
     console.log(`Error on getPostList with arg: ${arg}`);

--- a/src/lib/model/types.ts
+++ b/src/lib/model/types.ts
@@ -15,6 +15,12 @@ export interface InfiniteAction<Model, Arg = any, Data = any> extends BaseAction
     arg: Arg,
     meta: { previousData: Data | null; pageIndex: number }
   ) => Promise<Data | null>;
+  /**
+   * It is guaranteed that the former data will be passed before the later data.
+   * @param model
+   * @param payload
+   * @returns
+   */
   syncModel: (
     model: Draft<Model>,
     payload: { data: Data; arg: Arg; pageSize: number; pageIndex: number }

--- a/src/lib/utils/isNonNullable.ts
+++ b/src/lib/utils/isNonNullable.ts
@@ -1,0 +1,5 @@
+import { isUndefined } from './isUndefined';
+
+export function isNonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null && !isUndefined(value);
+}


### PR DESCRIPTION
Now `adapter.readPagination` will return the following data structure: 

```ts
type Return = {
	items: Data[],
	noMore: boolean,
	sizePerPage: number
}
```