### PR TITLE
test: add revalidate and fetching next page testing

### DIFF
--- a/src/__tests__/useInfiniteFetch-revalidateOnFocus.test.tsx
+++ b/src/__tests__/useInfiniteFetch-revalidateOnFocus.test.tsx
@@ -1,6 +1,6 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { useInfiniteFetch } from '../lib';
-import { createPostModel, getPostModelControl, sleep } from './utils';
+import { createPostModel, getPostModelControl, sleep, render } from './utils';
 
 describe('useInfiniteFetch revalidateOnFocus', () => {
   test('should revalidate when window get focused', async () => {
@@ -56,5 +56,30 @@ describe('useInfiniteFetch revalidateOnFocus', () => {
     screen.getByText('items: focus title0');
     fireEvent.click(screen.getByText('next'));
     await screen.findByText('items: focus title0 title1');
+  });
+
+  test('should fetch next page if revalidation and fetching next page are triggered concurrently', async () => {
+    const control = getPostModelControl({});
+    const { getPostList, postAdapter } = createPostModel(control);
+    function Page() {
+      const { data, fetchNextPage } = useInfiniteFetch(getPostList(), model =>
+        postAdapter.readPagination(model, '')
+      );
+
+      return (
+        <div>
+          items: {data?.items.map(item => item.title).join(' ')}
+          <button onClick={() => fetchNextPage()}>next</button>
+        </div>
+      );
+    }
+
+    render(<Page />);
+    screen.getByText('items:');
+    await screen.findByText('items: title0');
+    act(() => (control.titlePrefix = 'next'));
+    fireEvent.focus(window);
+    fireEvent.click(screen.getByText('next'));
+    await screen.findByText('items: title0 next title1');
   });
 });


### PR DESCRIPTION
When revalidation and fetching next page are triggered concurrently, we should abort the revalidation and execute fetching next page.