### PR TITLE
feat: return revalidate for each hook

### DIFF
--- a/src/lib/hooks/types.ts
+++ b/src/lib/hooks/types.ts
@@ -12,6 +12,7 @@ export interface HookReturn<D, E> {
   readonly data: D;
   readonly isFetching: boolean;
   readonly error: E | null;
+  revalidate: () => void;
 }
 
 export interface InfiniteHookReturn<D, E> extends HookReturn<D, E> {

--- a/src/lib/hooks/useFetch.ts
+++ b/src/lib/hooks/useFetch.ts
@@ -17,7 +17,7 @@ export function useFetch<M, Arg, RD, D = any, E = unknown>(
   getSnapshot: (model: M) => D,
   options: FetchOptions = {}
 ) {
-  const { stateDeps, status, data } = useModelAccessor(accessor, getSnapshot, options);
+  const { stateDeps, status, data, revalidate } = useModelAccessor(accessor, getSnapshot, options);
   const { isFetching, error } = status;
 
   return {
@@ -32,5 +32,6 @@ export function useFetch<M, Arg, RD, D = any, E = unknown>(
       stateDeps.error = true;
       return error;
     },
+    revalidate,
   };
 }

--- a/src/lib/hooks/useInfiniteFetch.ts
+++ b/src/lib/hooks/useInfiniteFetch.ts
@@ -19,7 +19,7 @@ export function useInfiniteFetch<M, Arg, RD, D = any, E = unknown>(
   getSnapshot: (model: M) => D,
   options: FetchOptions<D> = {}
 ) {
-  const { stateDeps, status, data } = useModelAccessor(accessor, getSnapshot, options);
+  const { stateDeps, status, data, revalidate } = useModelAccessor(accessor, getSnapshot, options);
   const { isFetching, error } = status;
 
   const fetchNextPage = useCallback(() => {
@@ -40,5 +40,6 @@ export function useInfiniteFetch<M, Arg, RD, D = any, E = unknown>(
       stateDeps.error = true;
       return error;
     },
+    revalidate,
   };
 }

--- a/src/lib/hooks/useModelAccessor.ts
+++ b/src/lib/hooks/useModelAccessor.ts
@@ -7,7 +7,12 @@ import { isNull } from '../utils/isNull';
 
 type StateDeps = Partial<Record<keyof Status, boolean>>;
 type Accessor<M, E> = NormalModelAccessor<M, any, any, E> | InfiniteModelAccessor<M, any, any, E>;
-type ReturnValue<D, E> = { stateDeps: StateDeps; status: Status<E>; data: D };
+type ReturnValue<D, E> = {
+  stateDeps: StateDeps;
+  status: Status<E>;
+  data: D;
+  revalidate: () => void;
+};
 
 const defaultStatus: Status = { isFetching: false, error: null };
 
@@ -99,5 +104,9 @@ export function useModelAccessor<M, D, E = unknown>(
     }
   }, [accessor, shouldRevalidate]);
 
-  return { stateDeps, status, data };
+  const revalidate = useCallback(() => {
+    accessor?.revalidate();
+  }, [accessor]);
+
+  return { stateDeps, status, data, revalidate };
 }


### PR DESCRIPTION
Return `revalidate` such that developer can manually determine when to revalidate the data.