### PR TITLE
feat: return useful promise for accessor.revalidate and fetchNext

### DIFF
--- a/src/__tests__/InfiniteAccessor.test.ts
+++ b/src/__tests__/InfiniteAccessor.test.ts
@@ -1,0 +1,61 @@
+import { defaultOptions } from '../lib/constants';
+import { createControl, createPost, createPostModel, sleep } from './utils';
+
+let control = createControl({});
+let getPostList = createPostModel(control).getPostList;
+const page0 = [createPost(0)];
+const page1 = [createPost(1)];
+
+describe('InfiniteAccessor', () => {
+  beforeEach(() => {
+    control = createControl({});
+    const model = createPostModel(control);
+    getPostList = model.getPostList;
+  });
+
+  test('should return data from revalidate and fetchNext', async () => {
+    expect(await getPostList().revalidate()).toEqual([[createPost(0)]]);
+    expect(await getPostList().fetchNext()).toEqual([page0, page1]);
+  });
+
+  test('should get the same promise if it is a duplicated revalidation', async () => {
+    const [promise1, promise2] = [getPostList().revalidate(), getPostList().revalidate()];
+    expect(promise1).toBe(promise2);
+  });
+
+  test('should get null if it is an expired revalidation', async () => {
+    control.sleepTime = 30;
+    const accessor = getPostList();
+    accessor.mount({ optionsRef: { current: { ...defaultOptions, dedupeInterval: 10 } } });
+    const promise1 = accessor.revalidate();
+    await sleep(10);
+    const promise2 = accessor.revalidate();
+
+    expect(await promise1).toBeNull();
+    expect(await promise2).toEqual([page0]);
+  });
+
+  test('should get null if it is aborted when error retry', async () => {
+    control.fetchDataError = new Error();
+    const accessor = getPostList();
+    accessor.mount({ optionsRef: { current: { ...defaultOptions, dedupeInterval: 10 } } });
+    const promise1 = accessor.revalidate();
+    await sleep(10);
+    control.fetchDataError = undefined;
+    const promise2 = accessor.revalidate();
+
+    expect(await promise1).toBeNull();
+    expect(await promise2).toEqual([page0]);
+  });
+
+  test('fetchNext should interrupt revalidate', async () => {
+    const accessor = getPostList();
+    await accessor.revalidate();
+    control.sleepTime = 30;
+    const promise1 = accessor.revalidate();
+    const promise2 = accessor.fetchNext();
+
+    expect(await promise1).toBeNull();
+    expect(await promise2).toEqual([page0, page1]);
+  });
+});

--- a/src/__tests__/NormalAccessor.test.ts
+++ b/src/__tests__/NormalAccessor.test.ts
@@ -1,0 +1,49 @@
+import { defaultOptions } from '../lib/constants';
+import { createControl, createPost, createPostModel, sleep } from './utils';
+
+let control = createControl({});
+let getPostById = createPostModel(control).getPostById;
+
+describe('NormalAccessor', () => {
+  beforeEach(() => {
+    control = createControl({});
+    const model = createPostModel(control);
+    getPostById = model.getPostById;
+  });
+
+  test('should return data from revalidate', async () => {
+    const data = await getPostById(0).revalidate();
+    expect(data).toEqual(createPost(0));
+  });
+
+  test('should get the same promise if it is a duplicated revalidation', async () => {
+    const accessor = getPostById(0);
+    const [promise1, promise2] = [accessor.revalidate(), accessor.revalidate()];
+    expect(promise1).toBe(promise2);
+  });
+
+  test('should get null if it is an expired revalidation', async () => {
+    control.sleepTime = 30;
+    const accessor = getPostById(0);
+    accessor.mount({ optionsRef: { current: { ...defaultOptions, dedupeInterval: 10 } } });
+    const promise1 = accessor.revalidate();
+    await sleep(10);
+    const promise2 = accessor.revalidate();
+
+    expect(await promise1).toBeNull();
+    expect(await promise2).toEqual(createPost(0));
+  });
+
+  test('should get null if it is aborted when error retry', async () => {
+    control.fetchDataError = new Error();
+    const accessor = getPostById(0);
+    accessor.mount({ optionsRef: { current: { ...defaultOptions, dedupeInterval: 10 } } });
+    const promise1 = accessor.revalidate();
+    await sleep(10);
+    control.fetchDataError = undefined;
+    const promise2 = accessor.revalidate();
+
+    expect(await promise1).toBeNull();
+    expect(await promise2).toEqual(createPost(0));
+  });
+});

--- a/src/__tests__/paginationAdapter.test.ts
+++ b/src/__tests__/paginationAdapter.test.ts
@@ -1,5 +1,5 @@
 import { createPaginationAdapter } from '../lib';
-import type { Post } from './types';
+import type { Post } from '../types';
 import { createPost } from './utils';
 
 describe('paginationAdapter', () => {
@@ -70,7 +70,7 @@ describe('paginationAdapter', () => {
       noMore: false,
     });
 
-    adapter.deleteOne(model, 0);
+    adapter.deleteOne(model, '0');
     expect(adapter.tryReadPagination(model, key)).toEqual({
       items: [...page0.slice(1), ...page1],
       noMore: false,
@@ -82,17 +82,17 @@ describe('paginationAdapter', () => {
       noMore: false,
     });
 
-    const post10 = createPost(10);
-    adapter.prependPagination(model, key, [post10]);
-    expect(adapter.tryReadPagination(model, key)?.items).toEqual([
-      post10,
-      ...page0.slice(1),
-      ...page1,
-      post0,
-    ]);
+    // const post10 = createPost(10);
+    // adapter.prependPagination(model, key, [post10]);
+    // expect(adapter.tryReadPagination(model, key)?.items).toEqual([
+    //   post10,
+    //   ...page0.slice(1),
+    //   ...page1,
+    //   post0,
+    // ]);
 
-    adapter.setNoMore(model, key, true);
-    expect(adapter.readPaginationMeta(model, key).noMore).toBe(true);
+    // adapter.setNoMore(model, key, true);
+    // expect(adapter.readPaginationMeta(model, key).noMore).toBe(true);
   });
 
   test('should transform rawData to data', () => {

--- a/src/__tests__/types.ts
+++ b/src/__tests__/types.ts
@@ -1,11 +1,3 @@
-export type PostLayout = 'classic' | 'image';
-
-export interface Post {
-  id: number;
-  title: string;
-  layout: PostLayout;
-}
-
 export type Func = (...args: any[]) => any;
 
 export interface PostModelControl {

--- a/src/__tests__/useAccessor-infinite-pollingInterval.test.tsx
+++ b/src/__tests__/useAccessor-infinite-pollingInterval.test.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import { createPostModel, createPostModelControl, render, sleep } from './utils';
+import { createPostModel, createControl, render, sleep } from './utils';
 import { useAccessor } from '../lib';
 import { fireEvent, waitFor, act } from '@testing-library/react';
 
 describe('useAccessor-infinite pollingInterval', () => {
   test('should keep revalidating if pollingInterval is larger than 0, and stop if it is smaller than 0', async () => {
     const onSuccessMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const [pollingInterval, setPollingInterval] = useState(10);
@@ -42,7 +42,7 @@ describe('useAccessor-infinite pollingInterval', () => {
 
   test('should stop polling revalidation if fetchNextPage is invoked', async () => {
     const onSuccessMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();

--- a/src/__tests__/useAccessor-infinite-revalidateOnFocus.test.tsx
+++ b/src/__tests__/useAccessor-infinite-revalidateOnFocus.test.tsx
@@ -1,10 +1,10 @@
 import { act, fireEvent, screen } from '@testing-library/react';
 import { useAccessor } from '../lib';
-import { createPostModel, createPostModelControl, sleep, render } from './utils';
+import { createPostModel, createControl, sleep, render } from './utils';
 
 describe('useAccessor-infinite revalidateOnFocus', () => {
   test('should revalidate when window get focused', async () => {
-    const control = createPostModelControl({ titlePrefix: 'focus' });
+    const control = createControl({ titlePrefix: 'focus' });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
@@ -31,7 +31,7 @@ describe('useAccessor-infinite revalidateOnFocus', () => {
   });
 
   test('should not revalidate when window get focused if revalidateOnFocus is set to false', async () => {
-    const control = createPostModelControl({ titlePrefix: 'focus' });
+    const control = createControl({ titlePrefix: 'focus' });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
@@ -59,7 +59,7 @@ describe('useAccessor-infinite revalidateOnFocus', () => {
   });
 
   test('should fetch next page if revalidation and fetching next page are triggered concurrently', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();

--- a/src/__tests__/useAccessor-infinite-revalidateOnReconnect.test.tsx
+++ b/src/__tests__/useAccessor-infinite-revalidateOnReconnect.test.tsx
@@ -1,10 +1,10 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { createPostModel, createPostModelControl, sleep } from './utils';
+import { createPostModel, createControl, sleep } from './utils';
 import { useAccessor } from '../lib';
 
 describe('useAccessor-infinite revalidateOnReconnect', () => {
   test('should revalidate when network reconnect', async () => {
-    const control = createPostModelControl({ titlePrefix: 'online' });
+    const control = createControl({ titlePrefix: 'online' });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
@@ -31,7 +31,7 @@ describe('useAccessor-infinite revalidateOnReconnect', () => {
   });
 
   test('should not revalidate when network reconnect if revalidateOnReconnect is set to false', async () => {
-    const control = createPostModelControl({ titlePrefix: 'online' });
+    const control = createControl({ titlePrefix: 'online' });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();

--- a/src/__tests__/useAccessor-infinite.test.tsx
+++ b/src/__tests__/useAccessor-infinite.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, act, waitFor } from '@testing-library/react';
 import { useAccessor } from '../lib';
-import { createPost, createPostModel, createPostModelControl, sleep } from './utils';
+import { createPost, createPostModel, createControl, sleep } from './utils';
 import type { PostModelControl } from './types';
 
 describe('useAccessor-infinite', () => {
@@ -113,7 +113,7 @@ describe('useAccessor-infinite', () => {
 
   test('should not cause an unhandled rejection when revalidate', async () => {
     const onErrorMock = vi.fn();
-    const control = createPostModelControl({ onErrorMock, fetchDataError: new Error('error') });
+    const control = createControl({ onErrorMock, fetchDataError: new Error('error') });
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostList(), postAdapter.tryReadPaginationFactory(''), {

--- a/src/__tests__/useAccessor-normal-dedupeInterval.test.tsx
+++ b/src/__tests__/useAccessor-normal-dedupeInterval.test.tsx
@@ -1,10 +1,10 @@
 import { useAccessor } from '../lib';
 import { act, render, screen } from '@testing-library/react';
-import { createPostModel, createPostModelControl, sleep } from './utils';
+import { createPostModel, createControl, sleep } from './utils';
 
 describe('useAccessor-normal dedupeInterval', () => {
   test('should sync model with the data from the latest request', async () => {
-    const control = createPostModelControl({ sleepTime: 100 });
+    const control = createControl({ sleepTime: 100 });
     const { postAdapter, getPostById } = createPostModel(control);
     const accessor = getPostById(0);
     function Page() {

--- a/src/__tests__/useAccessor-normal-pollingInterval.test.tsx
+++ b/src/__tests__/useAccessor-normal-pollingInterval.test.tsx
@@ -1,12 +1,12 @@
 import { act, fireEvent, waitFor } from '@testing-library/react';
 import { useAccessor } from '../lib';
-import { createPostModel, createPostModelControl, render, sleep } from './utils';
+import { createPostModel, createControl, render, sleep } from './utils';
 import { useState } from 'react';
 
 describe('useAccessor-normal pollingInterval', () => {
   test('should keep fetching data if pollingInterval is larger than 0, and stop fetching if it is smaller than 0', async () => {
     const onSuccessMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const [pollingInterval, setPollingInterval] = useState(10);
@@ -33,7 +33,7 @@ describe('useAccessor-normal pollingInterval', () => {
 
   test('should change the interval when the hook unmount', async () => {
     const onSuccessMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostById, postAdapter } = createPostModel(control);
     function Post({ pollingInterval }: { pollingInterval: number }) {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {
@@ -64,7 +64,7 @@ describe('useAccessor-normal pollingInterval', () => {
 
   test('should start polling when pollingInterval changes', async () => {
     const onSuccessMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const [pollingInterval, setPollingInterval] = useState(0);

--- a/src/__tests__/useAccessor-normal-revalidateOnFocus.test.tsx
+++ b/src/__tests__/useAccessor-normal-revalidateOnFocus.test.tsx
@@ -1,10 +1,10 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useAccessor } from '../lib';
-import { createPostModel, createPostModelControl, sleep } from './utils';
+import { createPostModel, createControl, sleep } from './utils';
 
 describe('useAccessor-normal revalidateOnFocus', () => {
   test('should revalidate when window get focused', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {
@@ -26,7 +26,7 @@ describe('useAccessor-normal revalidateOnFocus', () => {
   });
 
   test('should not revalidate when window get focused if revalidateOnFocus is set to false', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {

--- a/src/__tests__/useAccessor-normal-revalidateOnReconnect.test.tsx
+++ b/src/__tests__/useAccessor-normal-revalidateOnReconnect.test.tsx
@@ -1,10 +1,10 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useAccessor } from '../lib';
-import { createPostModel, createPostModelControl, sleep } from './utils';
+import { createPostModel, createControl, sleep } from './utils';
 
 describe('useAccessor-normal revalidateOnReconnect', () => {
   test('should revalidate when network reconnect', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {
@@ -26,7 +26,7 @@ describe('useAccessor-normal revalidateOnReconnect', () => {
   });
 
   test('should not revalidate when network reconnect if revalidateOnReconnect is set to false', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {

--- a/src/__tests__/useAccessor-normal.test.tsx
+++ b/src/__tests__/useAccessor-normal.test.tsx
@@ -1,11 +1,11 @@
 import { screen, fireEvent, act, waitFor } from '@testing-library/react';
-import { createPostModel, createPostModelControl, sleep, render } from './utils';
+import { createPostModel, createControl, sleep, render } from './utils';
 import { useState } from 'react';
 import { useAccessor } from '../lib';
 
 describe('useAccessor-normal', () => {
   test('should be able to update the cache', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const [id, setId] = useState(0);
@@ -22,7 +22,7 @@ describe('useAccessor-normal', () => {
   });
 
   test('should correctly mutate the cached value', async () => {
-    const control = createPostModelControl({});
+    const control = createControl({});
     const { getPostById, postAdapter, postModel } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0));
@@ -38,7 +38,7 @@ describe('useAccessor-normal', () => {
 
   test('should trigger onSuccess', async () => {
     const onSuccessMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const [id, setId] = useState(0);
@@ -58,7 +58,7 @@ describe('useAccessor-normal', () => {
 
   test('should trigger onError', async () => {
     const onErrorMock = vi.fn();
-    const control = createPostModelControl({ onErrorMock, fetchDataError: new Error('error') });
+    const control = createControl({ onErrorMock, fetchDataError: new Error('error') });
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const [id, setId] = useState(0);
@@ -81,7 +81,7 @@ describe('useAccessor-normal', () => {
 
   test('should hide the aborting error when any retry is aborted', async () => {
     const onErrorMock = vi.fn();
-    const control = createPostModelControl({ onErrorMock, fetchDataError: new Error('error') });
+    const control = createControl({ onErrorMock, fetchDataError: new Error('error') });
     const { getPostById, postAdapter } = createPostModel(control);
     function Page() {
       const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {

--- a/src/__tests__/useHydrate.test.tsx
+++ b/src/__tests__/useHydrate.test.tsx
@@ -1,14 +1,14 @@
 import { act, render } from '@testing-library/react';
 import { useAccessor, useHydrate } from '../lib';
 import type { Post } from './types';
-import { createPost, createPostModel, createPostModelControl, sleep } from './utils';
+import { createPost, createPostModel, createControl, sleep } from './utils';
 import { renderToString } from 'react-dom/server';
 
 describe('useHydrate', () => {
   test('should hydrate successfully', async () => {
     const onSuccessMock = vi.fn();
     const updateMock = vi.fn();
-    const control = createPostModelControl({ onSuccessMock });
+    const control = createControl({ onSuccessMock });
     const { getPostById, postAdapter, postModel } = createPostModel(control);
     function Component({ postId }: { postId: number }) {
       const { data } = useAccessor(getPostById(postId), postAdapter.tryReadOneFactory(postId), {

--- a/src/__tests__/utils.tsx
+++ b/src/__tests__/utils.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 import { StrictMode } from 'react';
 import { createModel, createPaginationAdapter } from '../lib';
-import type { PostLayout, Post, PostModelControl } from './types';
+import type { PostModelControl } from './types';
+import type { Post, PostLayout } from '../types';
 import { render as _render } from '@testing-library/react';
 
 export function sleep(time: number) {
@@ -9,7 +10,7 @@ export function sleep(time: number) {
 }
 
 export function createPost(id: number, layout: PostLayout = 'classic'): Post {
-  return { id, layout, title: `title${id}` };
+  return { id: `${id}`, layout, title: `title${id}` };
 }
 
 export function createPostModel(control: PostModelControl) {
@@ -80,7 +81,7 @@ export function createPostModel(control: PostModelControl) {
   return { postAdapter, postModel, getPostById, getPostList };
 }
 
-export function createPostModelControl(initialControl: PostModelControl) {
+export function createControl(initialControl: PostModelControl) {
   return initialControl;
 }
 


### PR DESCRIPTION
## Description

For `NormalAccessor`, `revalidate` now will return the promise which can be the data or `null`. It will be `null` when it is deduped.

`InfiniteAccessor` will return an array contains each page. Also, the `fetchNext` will return the same promise now.

## Related Issue

#54 

