### PR TITLE
refactor: inner state should be called state instead of model

### DIFF
--- a/src/__tests__/paginationAdapter.test.ts
+++ b/src/__tests__/paginationAdapter.test.ts
@@ -5,53 +5,53 @@ import { createPost } from './utils';
 describe('paginationAdapter', () => {
   const post0 = createPost(0);
   let adapter = createPaginationAdapter<Post>({});
-  let model = adapter.initialModel;
+  let state = adapter.initialState;
   beforeEach(() => {
     adapter = createPaginationAdapter({});
-    model = adapter.initialModel;
+    state = adapter.initialState;
   });
 
   test('CRUD', () => {
-    expect(adapter.tryReadOne(model, 0)).toBeUndefined();
-    expect(adapter.tryReadOneFactory(0)(model)).toBeUndefined();
-    expect(() => adapter.readOne(model, 0)).toThrowError();
+    expect(adapter.tryReadOne(state, 0)).toBeUndefined();
+    expect(adapter.tryReadOneFactory(0)(state)).toBeUndefined();
+    expect(() => adapter.readOne(state, 0)).toThrowError();
 
-    adapter.createOne(model, { ...post0 });
-    expect(adapter.tryReadOne(model, 0)).toEqual(post0);
-    expect(adapter.tryReadOneFactory(0)(model)).toEqual(post0);
-    expect(adapter.readOne(model, 0)).toEqual(post0);
+    adapter.createOne(state, { ...post0 });
+    expect(adapter.tryReadOne(state, 0)).toEqual(post0);
+    expect(adapter.tryReadOneFactory(0)(state)).toEqual(post0);
+    expect(adapter.readOne(state, 0)).toEqual(post0);
 
-    adapter.updateOne(model, 0, { layout: 'image' });
+    adapter.updateOne(state, 0, { layout: 'image' });
 
-    expect(adapter.tryReadOne(model, 0)).toEqual({ ...post0, layout: 'image' });
-    expect(adapter.tryReadOneFactory(0)(model)).toEqual({ ...post0, layout: 'image' });
-    expect(adapter.readOne(model, 0)).toEqual({ ...post0, layout: 'image' });
+    expect(adapter.tryReadOne(state, 0)).toEqual({ ...post0, layout: 'image' });
+    expect(adapter.tryReadOneFactory(0)(state)).toEqual({ ...post0, layout: 'image' });
+    expect(adapter.readOne(state, 0)).toEqual({ ...post0, layout: 'image' });
 
-    adapter.updateOne(model, 1, { layout: 'classic' });
-    expect(adapter.tryReadOne(model, 1)).toBeUndefined();
-    expect(adapter.tryReadOneFactory(1)(model)).toBeUndefined();
-    expect(() => adapter.readOne(model, 1)).toThrowError();
+    adapter.updateOne(state, 1, { layout: 'classic' });
+    expect(adapter.tryReadOne(state, 1)).toBeUndefined();
+    expect(adapter.tryReadOneFactory(1)(state)).toBeUndefined();
+    expect(() => adapter.readOne(state, 1)).toThrowError();
 
-    adapter.deleteOne(model, 0);
-    expect(adapter.tryReadOne(model, 0)).toBeUndefined();
-    expect(adapter.tryReadOneFactory(0)(model)).toBeUndefined();
-    expect(() => adapter.readOne(model, 1)).toThrowError();
+    adapter.deleteOne(state, 0);
+    expect(adapter.tryReadOne(state, 0)).toBeUndefined();
+    expect(adapter.tryReadOneFactory(0)(state)).toBeUndefined();
+    expect(() => adapter.readOne(state, 1)).toThrowError();
 
     // create a post
     const post1 = createPost(1);
-    adapter.upsertOne(model, { ...post1 });
-    expect(adapter.tryReadOne(model, 1)).toEqual({ ...post1 });
-    expect(adapter.readOne(model, 1)).toEqual({ ...post1 });
+    adapter.upsertOne(state, { ...post1 });
+    expect(adapter.tryReadOne(state, 1)).toEqual({ ...post1 });
+    expect(adapter.readOne(state, 1)).toEqual({ ...post1 });
     // update a post
-    adapter.upsertOne(model, { ...post1, layout: 'image' });
-    expect(adapter.tryReadOne(model, 1)).toEqual({ ...post1, layout: 'image' });
-    expect(adapter.readOne(model, 1)).toEqual({ ...post1, layout: 'image' });
+    adapter.upsertOne(state, { ...post1, layout: 'image' });
+    expect(adapter.tryReadOne(state, 1)).toEqual({ ...post1, layout: 'image' });
+    expect(adapter.readOne(state, 1)).toEqual({ ...post1, layout: 'image' });
   });
 
   test('pagination with CRUD', () => {
     const key = 'testing';
 
-    expect(adapter.tryReadPagination(model, key)).toBeUndefined();
+    expect(adapter.tryReadPagination(state, key)).toBeUndefined();
 
     const [page0, page1] = (() => {
       const data = new Array(10).fill(0).map((_, index) => {
@@ -59,40 +59,40 @@ describe('paginationAdapter', () => {
       });
       return [data.slice(0, 5), data.slice(5)];
     })();
-    adapter.replacePagination(model, key, page0);
-    expect(adapter.tryReadPagination(model, key)).toEqual({
+    adapter.replacePagination(state, key, page0);
+    expect(adapter.tryReadPagination(state, key)).toEqual({
       items: page0,
       noMore: false,
     });
-    adapter.appendPagination(model, key, page1);
-    expect(adapter.tryReadPagination(model, key)).toEqual({
+    adapter.appendPagination(state, key, page1);
+    expect(adapter.tryReadPagination(state, key)).toEqual({
       items: [...page0, ...page1],
       noMore: false,
     });
 
-    adapter.deleteOne(model, '0');
-    expect(adapter.tryReadPagination(model, key)).toEqual({
+    adapter.deleteOne(state, '0');
+    expect(adapter.tryReadPagination(state, key)).toEqual({
       items: [...page0.slice(1), ...page1],
       noMore: false,
     });
 
-    adapter.appendPagination(model, key, [{ ...post0 }]);
-    expect(adapter.tryReadPagination(model, key)).toEqual({
+    adapter.appendPagination(state, key, [{ ...post0 }]);
+    expect(adapter.tryReadPagination(state, key)).toEqual({
       items: [...page0.slice(1), ...page1, post0],
       noMore: false,
     });
 
-    // const post10 = createPost(10);
-    // adapter.prependPagination(model, key, [post10]);
-    // expect(adapter.tryReadPagination(model, key)?.items).toEqual([
-    //   post10,
-    //   ...page0.slice(1),
-    //   ...page1,
-    //   post0,
-    // ]);
+    const post10 = createPost(10);
+    adapter.prependPagination(state, key, [post10]);
+    expect(adapter.tryReadPagination(state, key)?.items).toEqual([
+      post10,
+      ...page0.slice(1),
+      ...page1,
+      post0,
+    ]);
 
-    // adapter.setNoMore(model, key, true);
-    // expect(adapter.readPaginationMeta(model, key).noMore).toBe(true);
+    adapter.setNoMore(state, key, true);
+    expect(adapter.readPaginationMeta(state, key).noMore).toBe(true);
   });
 
   test('should transform rawData to data', () => {
@@ -102,26 +102,26 @@ describe('paginationAdapter', () => {
         return { ...rawPost, content: 'content' };
       },
     });
-    const model = adapter.initialModel;
+    const state = adapter.initialState;
 
-    adapter.createOne(model, createPost(0));
-    expect(adapter.readOne(model, 0)).toEqual({ ...post0, content: 'content' });
-    adapter.deleteOne(model, 0);
-    expect(adapter.tryReadOne(model, 0)).toBeUndefined();
+    adapter.createOne(state, createPost(0));
+    expect(adapter.readOne(state, 0)).toEqual({ ...post0, content: 'content' });
+    adapter.deleteOne(state, 0);
+    expect(adapter.tryReadOne(state, 0)).toBeUndefined();
 
-    adapter.upsertOne(model, createPost(0));
-    expect(adapter.readOne(model, 0)).toEqual({ ...post0, content: 'content' });
-    adapter.deleteOne(model, 0);
-    expect(adapter.tryReadOne(model, 0)).toBeUndefined();
+    adapter.upsertOne(state, createPost(0));
+    expect(adapter.readOne(state, 0)).toEqual({ ...post0, content: 'content' });
+    adapter.deleteOne(state, 0);
+    expect(adapter.tryReadOne(state, 0)).toBeUndefined();
 
-    adapter.appendPagination(model, '', [createPost(0)]);
-    expect(adapter.readOne(model, 0)).toEqual({ ...post0, content: 'content' });
-    adapter.deleteOne(model, 0);
-    expect(adapter.tryReadOne(model, 0)).toBeUndefined();
+    adapter.appendPagination(state, '', [createPost(0)]);
+    expect(adapter.readOne(state, 0)).toEqual({ ...post0, content: 'content' });
+    adapter.deleteOne(state, 0);
+    expect(adapter.tryReadOne(state, 0)).toBeUndefined();
 
-    adapter.prependPagination(model, '', [createPost(0)]);
-    expect(adapter.readOne(model, 0)).toEqual({ ...post0, content: 'content' });
-    adapter.deleteOne(model, 0);
-    expect(adapter.tryReadOne(model, 0)).toBeUndefined();
+    adapter.prependPagination(state, '', [createPost(0)]);
+    expect(adapter.readOne(state, 0)).toEqual({ ...post0, content: 'content' });
+    adapter.deleteOne(state, 0);
+    expect(adapter.tryReadOne(state, 0)).toBeUndefined();
   });
 });

--- a/src/__tests__/useAccessor-infinite-dedupeInterval.test.tsx
+++ b/src/__tests__/useAccessor-infinite-dedupeInterval.test.tsx
@@ -4,14 +4,14 @@ import { createPost, createPostModel, sleep } from './utils';
 import { render, act, screen } from '@testing-library/react';
 
 describe('useAccessor-infinite dedupeInterval', () => {
-  test('should sync model with the data from the latest request', async () => {
+  test('should sync state with the data from the latest request', async () => {
     const control: PostModelControl = { sleepTime: 100, titlePrefix: 'with sleep' };
     const { postAdapter, postModel, getPostList } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
       const { data } = useAccessor(
         getPostList(),
-        model => postAdapter.tryReadPagination(model, ''),
+        state => postAdapter.tryReadPagination(state, ''),
         { dedupeInterval: 10 }
       );
 
@@ -36,11 +36,11 @@ describe('useAccessor-infinite dedupeInterval', () => {
     const post = createPost(0);
     post.title = `${control.titlePrefix} ${post.title}`;
     await screen.findByText(post.title);
-    expect(postAdapter.tryReadPagination(postModel.getModel(), '')?.items).toEqual([post]);
+    expect(postAdapter.tryReadPagination(postModel.getState(), '')?.items).toEqual([post]);
 
-    // The expired request should not update the model
+    // The expired request should not update the state
     await act(() => sleep(100));
     await screen.findByText(post.title);
-    expect(postAdapter.tryReadPagination(postModel.getModel(), '')?.items).toEqual([post]);
+    expect(postAdapter.tryReadPagination(postModel.getState(), '')?.items).toEqual([post]);
   });
 });

--- a/src/__tests__/useAccessor-infinite-pollingInterval.test.tsx
+++ b/src/__tests__/useAccessor-infinite-pollingInterval.test.tsx
@@ -12,7 +12,7 @@ describe('useAccessor-infinite pollingInterval', () => {
       const [pollingInterval, setPollingInterval] = useState(10);
       const { data } = useAccessor(
         getPostList(),
-        model => postAdapter.tryReadPagination(model, ''),
+        state => postAdapter.tryReadPagination(state, ''),
         { pollingInterval }
       );
 
@@ -46,7 +46,7 @@ describe('useAccessor-infinite pollingInterval', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''), {
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''), {
         pollingInterval: 10,
       });
 

--- a/src/__tests__/useAccessor-infinite-revalidateIfStale.test.tsx
+++ b/src/__tests__/useAccessor-infinite-revalidateIfStale.test.tsx
@@ -11,8 +11,8 @@ describe('useAccessor-infinite revalidateIfStale', async () => {
     };
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
-      const { data } = useAccessor(getPostList(), model =>
-        postAdapter.tryReadPagination(model, '')
+      const { data } = useAccessor(getPostList(), state =>
+        postAdapter.tryReadPagination(state, '')
       );
 
       return (
@@ -38,7 +38,7 @@ describe('useAccessor-infinite revalidateIfStale', async () => {
     function Page() {
       const { data } = useAccessor(
         getPostList(),
-        model => postAdapter.tryReadPagination(model, ''),
+        state => postAdapter.tryReadPagination(state, ''),
         { revalidateIfStale: false }
       );
 
@@ -52,8 +52,8 @@ describe('useAccessor-infinite revalidateIfStale', async () => {
       );
     }
 
-    postModel.mutate(model => {
-      postAdapter.replacePagination(model, '', [createPost(0)]);
+    postModel.mutate(draft => {
+      postAdapter.replacePagination(draft, '', [createPost(0)]);
     });
     render(<Page />);
     screen.getByText('items: title0');

--- a/src/__tests__/useAccessor-infinite-revalidateOnFocus.test.tsx
+++ b/src/__tests__/useAccessor-infinite-revalidateOnFocus.test.tsx
@@ -8,7 +8,7 @@ describe('useAccessor-infinite revalidateOnFocus', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''), {
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''), {
         revalidateOnFocus: true,
       });
 
@@ -35,7 +35,7 @@ describe('useAccessor-infinite revalidateOnFocus', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''), {
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''), {
         revalidateOnFocus: false,
       });
 
@@ -63,7 +63,7 @@ describe('useAccessor-infinite revalidateOnFocus', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''));
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''));
 
       return (
         <div>

--- a/src/__tests__/useAccessor-infinite-revalidateOnReconnect.test.tsx
+++ b/src/__tests__/useAccessor-infinite-revalidateOnReconnect.test.tsx
@@ -8,7 +8,7 @@ describe('useAccessor-infinite revalidateOnReconnect', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''), {
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''), {
         revalidateOnReconnect: true,
       });
 
@@ -35,7 +35,7 @@ describe('useAccessor-infinite revalidateOnReconnect', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''), {
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''), {
         revalidateOnReconnect: false,
       });
 

--- a/src/__tests__/useAccessor-infinite.test.tsx
+++ b/src/__tests__/useAccessor-infinite.test.tsx
@@ -8,7 +8,7 @@ describe('useAccessor-infinite', () => {
     const { getPostList, postAdapter } = createPostModel({});
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''));
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''));
 
       return (
         <div>
@@ -29,7 +29,7 @@ describe('useAccessor-infinite', () => {
     const { getPostList, postAdapter, postModel } = createPostModel({});
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''));
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''));
 
       return (
         <div>
@@ -42,7 +42,7 @@ describe('useAccessor-infinite', () => {
     render(<Page />);
     screen.getByText('items:');
     await screen.findByText('items: title0');
-    act(() => postModel.mutate(model => postAdapter.updateOne(model, 0, { title: 'mutated' })));
+    act(() => postModel.mutate(state => postAdapter.updateOne(state, 0, { title: 'mutated' })));
     await screen.findByText('items: mutated');
     fireEvent.click(screen.getByText('next'));
     await screen.findByText('items: mutatedtitle1');
@@ -54,7 +54,7 @@ describe('useAccessor-infinite', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''));
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''));
 
       return (
         <div>
@@ -84,7 +84,7 @@ describe('useAccessor-infinite', () => {
     const { getPostList, postAdapter } = createPostModel(control);
     function Page() {
       const accessor = getPostList();
-      const { data } = useAccessor(accessor, model => postAdapter.tryReadPagination(model, ''), {
+      const { data } = useAccessor(accessor, state => postAdapter.tryReadPagination(state, ''), {
         retryCount: 0,
       });
 

--- a/src/__tests__/useAccessor-normal-dedupeInterval.test.tsx
+++ b/src/__tests__/useAccessor-normal-dedupeInterval.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from '@testing-library/react';
 import { createPostModel, createControl, sleep } from './utils';
 
 describe('useAccessor-normal dedupeInterval', () => {
-  test('should sync model with the data from the latest request', async () => {
+  test('should sync state with the data from the latest request', async () => {
     const control = createControl({ sleepTime: 100 });
     const { postAdapter, getPostById } = createPostModel(control);
     const accessor = getPostById(0);

--- a/src/__tests__/useAccessor-normal-revalidateIfStale.test.tsx
+++ b/src/__tests__/useAccessor-normal-revalidateIfStale.test.tsx
@@ -34,8 +34,8 @@ describe('useAccessor-normal revalidateIfStale', async () => {
       return <div>title: {data?.title}</div>;
     }
 
-    postModel.mutate(model => {
-      postAdapter.createOne(model, createPost(0));
+    postModel.mutate(state => {
+      postAdapter.createOne(state, createPost(0));
     });
     render(<Page />);
     screen.getByText('title: title0');

--- a/src/__tests__/useAccessor-normal.test.tsx
+++ b/src/__tests__/useAccessor-normal.test.tsx
@@ -32,7 +32,7 @@ describe('useAccessor-normal', () => {
 
     render(<Page />);
     await screen.findByText('title0');
-    act(() => postModel.mutate(model => (postAdapter.readOne(model, 0).title = 'mutated value')));
+    act(() => postModel.mutate(draft => (postAdapter.readOne(draft, 0).title = 'mutated value')));
     await screen.findByText('mutated value');
   });
 

--- a/src/__tests__/utils.tsx
+++ b/src/__tests__/utils.tsx
@@ -15,7 +15,7 @@ export function createPost(id: number, layout: PostLayout = 'classic'): Post {
 
 export function createPostModel(control: PostModelControl) {
   const postAdapter = createPaginationAdapter<Post>({});
-  const postModel = createModel(postAdapter.initialModel);
+  const postModel = createModel(postAdapter.initialState);
   const getPostById = postModel.defineAccessor('normal', {
     fetchData: async (id: number) => {
       control.fetchDataMock?.();
@@ -34,8 +34,8 @@ export function createPostModel(control: PostModelControl) {
       }
       return post;
     },
-    syncModel: (model, { data }) => {
-      postAdapter.createOne(model, data);
+    syncState: (draft, { data }) => {
+      postAdapter.createOne(draft, data);
     },
     onSuccess: info => {
       control.onSuccessMock?.(info);
@@ -62,12 +62,12 @@ export function createPostModel(control: PostModelControl) {
       }
       return [post];
     },
-    syncModel(model, { pageIndex, data }) {
+    syncState(draft, { pageIndex, data }) {
       const paginationKey = '';
       if (pageIndex === 0) {
-        postAdapter.replacePagination(model, paginationKey, data);
+        postAdapter.replacePagination(draft, paginationKey, data);
       } else {
-        postAdapter.appendPagination(model, paginationKey, data);
+        postAdapter.appendPagination(draft, paginationKey, data);
       }
     },
     onSuccess: info => {

--- a/src/example/components/PostList.tsx
+++ b/src/example/components/PostList.tsx
@@ -7,8 +7,8 @@ export function PostList() {
   const [layout, setLayout] = useState<PostLayout>('classic');
   const key = JSON.stringify({ layout });
   const accessor = getPostList({ layout });
-  const { data } = useAccessor(accessor, model => {
-    return postAdapter.tryReadPagination(model, key);
+  const { data } = useAccessor(accessor, state => {
+    return postAdapter.tryReadPagination(state, key);
   });
 
   const loadMore = () => {

--- a/src/example/hooks/usePost.ts
+++ b/src/example/hooks/usePost.ts
@@ -9,8 +9,8 @@ interface Props extends FetchOptions {
 export function usePost({ id, ...options }: Props) {
   const { data } = useAccessor(
     getPostById(id),
-    model => {
-      return model.entityRecord[id];
+    state => {
+      return state.entityRecord[id];
     },
     { ...options }
   );

--- a/src/example/model/postModel.ts
+++ b/src/example/model/postModel.ts
@@ -4,16 +4,15 @@ import { createPaginationAdapter } from '../../lib';
 import { getPostById as getPostByIdRequest, getPostList as getPostListRequest } from '../request';
 
 export const postAdapter = createPaginationAdapter<Post>({});
-const initialModel = postAdapter.initialModel;
 
-export const postModel = createModel(initialModel);
+export const postModel = createModel(postAdapter.initialState);
 
 export const getPostById = postModel.defineAccessor('normal', {
   fetchData: async (id: number) => {
     const data = await getPostByIdRequest(id);
     return data;
   },
-  syncModel: (draft, { data }) => {
+  syncState: (draft, { data }) => {
     postAdapter.upsertOne(draft, data);
   },
   onError: ({ error, arg }) => {
@@ -32,7 +31,7 @@ export const getPostList = postModel.defineAccessor<{ layout: PostLayout }, Post
     const data = await getPostListRequest({ layout, page: pageIndex });
     return data;
   },
-  syncModel: (draft, { data, arg, pageIndex }) => {
+  syncState: (draft, { data, arg, pageIndex }) => {
     const paginationKey = JSON.stringify(arg);
     if (pageIndex === 0) {
       postAdapter.replacePagination(draft, paginationKey, data);

--- a/src/lib/hooks/useAccessor.ts
+++ b/src/lib/hooks/useAccessor.ts
@@ -7,7 +7,7 @@ import { isNull } from '../utils/isNull';
 import { accessorOptionsContext } from '../contexts';
 
 type StateDeps = Partial<Record<keyof Status | 'data', boolean>>;
-type Accessor<M, E> = NormalAccessor<M, any, any, E> | InfiniteAccessor<M, any, any, E>;
+type Accessor<S, E> = NormalAccessor<S, any, any, E> | InfiniteAccessor<S, any, any, E>;
 type ReturnValue<D, E> = {
   readonly isFetching: boolean;
   readonly error: E;
@@ -16,19 +16,19 @@ type ReturnValue<D, E> = {
 
 const defaultStatus: Status = { isFetching: false, error: null };
 
-export function useAccessor<M, D, E = unknown>(
-  accessor: Accessor<M, E>,
-  getSnapshot: (model: M) => D,
+export function useAccessor<S, D, E = unknown>(
+  accessor: Accessor<S, E>,
+  getSnapshot: (state: S) => D,
   options?: FetchOptions<D>
 ): ReturnValue<D, E>;
-export function useAccessor<M, D, E = unknown>(
-  accessor: Accessor<M, E> | null,
-  getSnapshot: (model: M) => D,
+export function useAccessor<S, D, E = unknown>(
+  accessor: Accessor<S, E> | null,
+  getSnapshot: (state: S) => D,
   options?: FetchOptions<D>
 ): ReturnValue<D | undefined, E>;
-export function useAccessor<M, D, E = unknown>(
-  accessor: Accessor<M, E> | null,
-  getSnapshot: (model: M) => D,
+export function useAccessor<S, D, E = unknown>(
+  accessor: Accessor<S, E> | null,
+  getSnapshot: (state: S) => D,
   options: FetchOptions<D> = {}
 ): ReturnValue<D, E> {
   const {
@@ -68,13 +68,13 @@ export function useAccessor<M, D, E = unknown>(
       return [() => noop, noop];
     }
 
-    let memoizedSnapshot = getSnapshot(accessor.getModel());
+    let memoizedSnapshot = getSnapshot(accessor.getState());
 
     return [
       (listener: () => void) => {
         return accessor.subscribeData(() => {
           if (!stateDeps.data) return;
-          const snapshot = getSnapshot(accessor.getModel());
+          const snapshot = getSnapshot(accessor.getState());
           if (stableHash(snapshot) !== stableHash(memoizedSnapshot)) {
             memoizedSnapshot = snapshot;
             listener();

--- a/src/lib/model/Accessor.ts
+++ b/src/lib/model/Accessor.ts
@@ -35,10 +35,10 @@ export abstract class Accessor<M, D, E> {
    */
   abstract revalidate: () => Promise<D | null> | null;
 
-  getModel: () => M;
+  getState: () => M;
 
-  constructor(getModel: () => M, modelSubscribe: ModelSubscribe) {
-    this.getModel = getModel;
+  constructor(getState: () => M, modelSubscribe: ModelSubscribe) {
+    this.getState = getState;
     this.modelSubscribe = modelSubscribe;
   }
 

--- a/src/lib/model/InfiniteAccessor.ts
+++ b/src/lib/model/InfiniteAccessor.ts
@@ -6,14 +6,14 @@ import type { Draft } from 'immer';
 
 type Task = 'validate' | 'next' | 'idle';
 
-export class InfiniteAccessor<M, Arg = any, Data = any, E = unknown> extends Accessor<
-  M,
+export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Accessor<
+  S,
   Data[],
   E
 > {
-  private action: InfiniteAction<M, Arg, Data>;
+  private action: InfiniteAction<S, Arg, Data>;
   private arg: Arg;
-  private updateModel: (cb: (draft: Draft<M>) => void) => void;
+  private updateState: (cb: (draft: Draft<S>) => void) => void;
   private data: Data[] = [];
   /**
    * This property is used to reject ant ongoing fetching.
@@ -26,16 +26,16 @@ export class InfiniteAccessor<M, Arg = any, Data = any, E = unknown> extends Acc
 
   constructor(
     arg: Arg,
-    action: InfiniteAction<M, Arg, Data>,
-    updateModel: (cb: (draft: Draft<M>) => void) => void,
-    getModel: () => M,
+    action: InfiniteAction<S, Arg, Data>,
+    updateState: (cb: (draft: Draft<S>) => void) => void,
+    getState: () => S,
     modelSubscribe: ModelSubscribe,
     notifyModel: () => void
   ) {
-    super(getModel, modelSubscribe);
+    super(getState, modelSubscribe);
     this.arg = arg;
     this.action = action;
-    this.updateModel = updateModel;
+    this.updateState = updateState;
     this.notifyModel = notifyModel;
   }
 
@@ -183,15 +183,15 @@ export class InfiniteAccessor<M, Arg = any, Data = any, E = unknown> extends Acc
   };
 
   /**
-   * Sync the data in `data` from the `start` index to the model,
+   * Sync the data in `data` from the `start` index to the state,
    * and notify the listeners which are listening this accessor.
    */
   private flush = (data: Data[], { start }: { start: number }) => {
     const pageSize = data.length;
     data.forEach((data, pageIndex) => {
       if (pageIndex < start) return;
-      this.updateModel(draft => {
-        this.action.syncModel(draft, {
+      this.updateState(draft => {
+        this.action.syncState(draft, {
           data,
           arg: this.arg,
           pageIndex,

--- a/src/lib/model/Model.ts
+++ b/src/lib/model/Model.ts
@@ -7,20 +7,20 @@ import { stableHash } from '../utils';
 
 type Accessor<M> = NormalAccessor<M> | InfiniteAccessor<M>;
 
-export function createModel<M extends object>(initialModel: M) {
+export function createModel<S extends object>(initialState: S) {
   let prefixCounter = 0;
-  let model = initialModel;
+  let state = initialState;
   const listeners: (() => void)[] = [];
-  const accessors = {} as Record<string, Accessor<M> | undefined>;
+  const accessors = {} as Record<string, Accessor<S> | undefined>;
 
-  function updateModel(fn: (draft: Draft<M>) => void) {
-    const draft = createDraft(model);
+  function updateState(fn: (draft: Draft<S>) => void) {
+    const draft = createDraft(state);
     fn(draft);
-    model = finishDraft(draft) as M;
+    state = finishDraft(draft) as S;
   }
 
-  function getModel() {
-    return model;
+  function getState() {
+    return state;
   }
 
   function subscribe(listener: () => void) {
@@ -35,22 +35,22 @@ export function createModel<M extends object>(initialModel: M) {
     listeners.forEach(l => l());
   }
 
-  function mutate(fn: (draft: Draft<M>) => void) {
-    updateModel(fn);
+  function mutate(fn: (draft: Draft<S>) => void) {
+    updateState(fn);
     notifyListeners();
   }
 
   function defineAccessor<Arg, Data>(
     type: 'normal',
-    action: NormalAction<M, Arg, Data>
-  ): (arg: Arg) => NormalAccessor<M, Arg, Data>;
+    action: NormalAction<S, Arg, Data>
+  ): (arg: Arg) => NormalAccessor<S, Arg, Data>;
   function defineAccessor<Arg, Data>(
     type: 'infinite',
-    action: InfiniteAction<M, Arg, Data>
-  ): (arg: Arg) => InfiniteAccessor<M, Arg, Data>;
+    action: InfiniteAction<S, Arg, Data>
+  ): (arg: Arg) => InfiniteAccessor<S, Arg, Data>;
   function defineAccessor<Arg, Data>(
     type: 'normal' | 'infinite',
-    action: NormalAction<M, Arg, Data> | InfiniteAction<M, Arg, Data>
+    action: NormalAction<S, Arg, Data> | InfiniteAction<S, Arg, Data>
   ) {
     const prefix = prefixCounter++;
 
@@ -63,8 +63,8 @@ export function createModel<M extends object>(initialModel: M) {
         const constructorArgs = [
           arg,
           action as any,
-          updateModel,
-          getModel,
+          updateState,
+          getState,
           subscribe,
           notifyListeners,
         ] as const;
@@ -80,5 +80,5 @@ export function createModel<M extends object>(initialModel: M) {
     };
   }
 
-  return { mutate, defineAccessor, getModel };
+  return { mutate, defineAccessor, getState };
 }

--- a/src/lib/model/NormalAccessor.ts
+++ b/src/lib/model/NormalAccessor.ts
@@ -9,28 +9,24 @@ import type { Draft } from 'immer';
  */
 type FetchResult<D, E> = [D | null, E | null];
 
-export class NormalAccessor<Model, Arg = any, Data = any, E = unknown> extends Accessor<
-  Model,
-  Data,
-  E
-> {
-  private action: NormalAction<Model, Arg, Data, E>;
+export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Accessor<S, Data, E> {
+  private action: NormalAction<S, Arg, Data, E>;
   private arg: Arg;
-  private updateModel: (cb: (model: Draft<Model>) => void) => void;
+  private updateState: (cb: (draft: Draft<S>) => void) => void;
   private notifyModel: () => void;
 
   constructor(
     arg: Arg,
-    action: NormalAction<Model, Arg, Data>,
-    updateModel: (cb: (model: Draft<Model>) => void) => void,
-    getModel: () => Model,
+    action: NormalAction<S, Arg, Data>,
+    updateState: (cb: (draft: Draft<S>) => void) => void,
+    getState: () => S,
     modelSubscribe: ModelSubscribe,
     notifyModel: () => void
   ) {
-    super(getModel, modelSubscribe);
+    super(getState, modelSubscribe);
     this.action = action;
     this.arg = arg;
-    this.updateModel = updateModel;
+    this.updateState = updateState;
     this.notifyModel = notifyModel;
   }
 
@@ -51,8 +47,8 @@ export class NormalAccessor<Model, Arg = any, Data = any, E = unknown> extends A
         this.updateStartAt(startAt);
 
         if (data) {
-          this.updateModel(draft => {
-            this.action.syncModel(draft, { data, arg, startAt });
+          this.updateState(draft => {
+            this.action.syncState(draft, { data, arg, startAt });
           });
           this.updateStatus({ error: null });
           this.action.onSuccess?.({ data, arg });

--- a/src/lib/model/types.ts
+++ b/src/lib/model/types.ts
@@ -16,33 +16,27 @@ interface BaseAction<Arg, D, E> {
   onSuccess?: (info: { data: D; arg: Arg }) => void;
 }
 
-export interface NormalAction<Model, Arg = any, Data = any, E = unknown>
+export interface NormalAction<S, Arg = any, Data = any, E = unknown>
   extends BaseAction<Arg, Data, E> {
   fetchData: (arg: Arg) => Promise<Data>;
-  syncModel: (model: Draft<Model>, payload: BasePayload<Arg, Data>) => void;
+  syncState: (draft: Draft<S>, payload: BasePayload<Arg, Data>) => void;
 }
 
-export interface InfiniteAction<Model, Arg = any, Data = any, E = unknown>
+export interface InfiniteAction<S, Arg = any, Data = any, E = unknown>
   extends BaseAction<Arg, Data[], E> {
   fetchData: (
     arg: Arg,
     meta: { previousData: Data | null; pageIndex: number }
   ) => Promise<Data | null>;
-  /**
-   * It is guaranteed that the former data will be passed before the later data.
-   * @param model
-   * @param payload
-   * @returns
-   */
-  syncModel: (
-    model: Draft<Model>,
+  syncState: (
+    draft: Draft<S>,
     payload: { data: Data; arg: Arg; pageSize: number; pageIndex: number }
   ) => void;
 }
 
-export type Action<Model, Arg = any, Data = any> =
-  | NormalAction<Model, Arg, Data>
-  | InfiniteAction<Model, Arg, Data>;
+export type Action<S, Arg = any, Data = any, E = unknown> =
+  | NormalAction<S, Arg, Data, E>
+  | InfiniteAction<S, Arg, Data, E>;
 
 export type ArgFromAction<A extends Action<any>> = Parameters<A['fetchData']>[0];
 


### PR DESCRIPTION
## Description

The inner state should be called `state` instead of `model`. This is a breaking change since `getModel` cannot be used now.

## Related Issue

close #73 