### PR TITLE
feat: support setIsStale and getIsStale

### DIFF
--- a/src/__tests__/useAccessor-revalidateIfStale.test.tsx
+++ b/src/__tests__/useAccessor-revalidateIfStale.test.tsx
@@ -1,0 +1,66 @@
+import { waitFor } from '@testing-library/react';
+import { useAccessor } from '../lib';
+import { createControl, createPost, createPostModel, renderWithOptionsProvider } from './utils';
+
+describe('useAccessor-normal revalidateIfStale', () => {
+  test('should revalidate if the data is marked as stale', async () => {
+    const fetchDataMock = vi.fn();
+    const control = createControl({ fetchDataMock });
+    const { getPostById, postAdapter, postModel } = createPostModel(control);
+    const accessor = getPostById(0);
+    function Page() {
+      const { data } = useAccessor(getPostById(0), postAdapter.tryReadOneFactory(0), {
+        revalidateIfStale: true,
+      });
+
+      return <div>title: {data?.title}</div>;
+    }
+    postModel.mutate(draft => {
+      postAdapter.createOne(draft, createPost(0));
+    });
+    accessor.setIsStale(true);
+
+    const { getByText } = renderWithOptionsProvider(<Page />);
+    getByText('title: title0');
+    await waitFor(() => {
+      expect(fetchDataMock).toHaveBeenCalledTimes(1);
+    });
+
+    accessor.setIsStale(true);
+    await waitFor(() => {
+      expect(fetchDataMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('useAccessor-infinite revalidateIfStale', () => {
+  test('should revalidate if the data is marked as stale', async () => {
+    const fetchDataMock = vi.fn();
+    const control = createControl({ fetchDataMock });
+    const { getPostList, postAdapter, postModel } = createPostModel(control);
+    const key = '';
+    const accessor = getPostList();
+    function Page() {
+      const { data } = useAccessor(accessor, postAdapter.tryReadPaginationFactory(key), {
+        revalidateIfStale: true,
+      });
+
+      return <div>{data?.items.map(post => post.title)}</div>;
+    }
+    postModel.mutate(draft => {
+      postAdapter.appendPagination(draft, key, [createPost(0)]);
+    });
+    accessor.setIsStale(true);
+
+    const { getByText } = renderWithOptionsProvider(<Page />);
+    getByText('title0');
+    await waitFor(() => {
+      expect(fetchDataMock).toHaveBeenCalledTimes(1);
+    });
+
+    accessor.setIsStale(true);
+    await waitFor(() => {
+      expect(fetchDataMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,5 +10,5 @@ export const defaultOptions: RequiredAccessorOptions = {
   revalidateOnReconnect: false,
   dedupeInterval: 2000,
   pollingInterval: 0,
-  checkHasStaleData: value => !isUndefined(value),
+  checkHasData: value => !isUndefined(value),
 };

--- a/src/lib/hooks/types.ts
+++ b/src/lib/hooks/types.ts
@@ -3,7 +3,7 @@ export interface AccessorOptions<S = any> {
   revalidateOnReconnect?: boolean;
   revalidateOnMount?: boolean;
   revalidateIfStale?: boolean;
-  checkHasStaleData?: (snapshot: S) => boolean;
+  checkHasData?: (snapshot: S) => boolean;
   retryCount?: number;
   retryInterval?: number;
   dedupeInterval?: number;


### PR DESCRIPTION
## Proposed change

Developer now can set the data, for which the accessor is responsible for fetching, to stale such that the `useAccessor` can determine whether it should revalidate the stale data.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Testing
- [ ] Refactor
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

## Related Issue

close #75 
