### PR TITLE
feat: add serverStateKey for model

### DIFF
--- a/src/__tests__/createModel.test.ts
+++ b/src/__tests__/createModel.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @vitest-environment node
+ */
+
+import { createControl, createPost, createPostModel } from './utils';
+
+const control = createControl({});
+
+describe('createModel', () => {
+  test('should access the same state in the server if server state key is the same', () => {
+    const { postModel, postAdapter } = createPostModel(control);
+    const serverStateKey = {};
+    postModel.mutate(draft => {
+      postAdapter.createOne(draft, createPost(0));
+    }, serverStateKey);
+
+    const state = postModel.getState(serverStateKey);
+    expect(postAdapter.readOne(state, 0)).toEqual(createPost(0));
+    // different key should get different state.
+    expect(postAdapter.tryReadOne(postModel.getState({}), 0)).toBeUndefined();
+  });
+});

--- a/src/lib/contexts/ServerStateKeyContext.tsx
+++ b/src/lib/contexts/ServerStateKeyContext.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+
+const serverStateKeyContext = createContext<object | undefined>(undefined);
+
+export interface ServerStateKeyProviderProps {
+  value: object;
+  children: ReactNode;
+}
+
+export function useServerStateKeyContext() {
+  return useContext(serverStateKeyContext);
+}
+
+export function ServerStateKeyProvider({ value, children }: ServerStateKeyProviderProps) {
+  return <serverStateKeyContext.Provider value={value}>{children}</serverStateKeyContext.Provider>;
+}

--- a/src/lib/contexts/index.ts
+++ b/src/lib/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './AccessorOptionsContext';
+export * from './ServerStateKeyContext';

--- a/src/lib/hooks/useHydrate.ts
+++ b/src/lib/hooks/useHydrate.ts
@@ -1,8 +1,23 @@
+import { useServerStateKeyContext } from '../contexts';
+import { isServer } from '../utils';
+
 const dataset = new WeakSet();
 
-export function useHydrate<T extends object>(data: T, update: () => void): void {
+export function useHydrate<T extends object>(
+  data: T,
+  update: (serverStateKey?: object) => void
+): void {
+  const serverStateKey = useServerStateKeyContext();
+
+  if (isServer()) {
+    if (!dataset.has(data)) {
+      dataset.add(data);
+      update(serverStateKey);
+    }
+  }
+
   if (!dataset.has(data)) {
     dataset.add(data);
-    update();
+    update(serverStateKey);
   }
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,7 +2,7 @@ import type { InfiniteAction, NormalAction } from './model/types';
 import type { InfiniteAccessorCreator, NormalAccessorCreator } from './model/Model';
 import type { AccessorOptions, UseAccessorReturn } from './hooks/types';
 import type { NormalAccessor, InfiniteAccessor, Accessor } from './model';
-import type { AccessorOptionsProviderProps } from './contexts';
+import type { AccessorOptionsProviderProps, ServerStateKeyProviderProps } from './contexts';
 import type {
   PaginationAdapter,
   Pagination,
@@ -13,7 +13,11 @@ import type {
 import { createModel } from './model';
 import { useAccessor, useHydrate } from './hooks';
 import { createPaginationAdapter } from './adapters';
-import { AccessorOptionsProvider } from './contexts';
+import {
+  AccessorOptionsProvider,
+  ServerStateKeyProvider,
+  useServerStateKeyContext,
+} from './contexts';
 
 export type {
   AccessorOptions,
@@ -21,11 +25,14 @@ export type {
   NormalAccessor,
   InfiniteAccessor,
   Accessor,
-  AccessorOptionsProviderProps,
   InfiniteAccessorCreator,
   NormalAccessorCreator,
   InfiniteAction,
   NormalAction,
+
+  // context
+  AccessorOptionsProviderProps,
+  ServerStateKeyProviderProps,
 
   // adapter
   PaginationAdapter,
@@ -34,4 +41,16 @@ export type {
   PaginationState,
   Id,
 };
-export { createModel, useAccessor, useHydrate, createPaginationAdapter, AccessorOptionsProvider };
+export {
+  createModel,
+  useAccessor,
+  useHydrate,
+
+  // adapter
+  createPaginationAdapter,
+
+  // context
+  AccessorOptionsProvider,
+  ServerStateKeyProvider,
+  useServerStateKeyContext,
+};

--- a/src/lib/model/Accessor.ts
+++ b/src/lib/model/Accessor.ts
@@ -42,12 +42,12 @@ export abstract class Accessor<S, D, E> {
   /**
    * Get the state of the corresponding model.
    */
-  getState: () => S;
+  getState: (serverStateKey?: object) => S;
 
   /**
    * @internal
    */
-  constructor(getState: () => S, modelSubscribe: ModelSubscribe) {
+  constructor(getState: (serverStateKey?: object) => S, modelSubscribe: ModelSubscribe) {
     this.getState = getState;
     this.modelSubscribe = modelSubscribe;
   }

--- a/src/lib/model/InfiniteAccessor.ts
+++ b/src/lib/model/InfiniteAccessor.ts
@@ -31,7 +31,7 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Acc
     arg: Arg,
     action: InfiniteAction<S, Arg, Data>,
     updateState: (cb: (draft: Draft<S>) => void) => void,
-    getState: () => S,
+    getState: (serverStateKey?: object) => S,
     modelSubscribe: ModelSubscribe,
     notifyModel: () => void
   ) {

--- a/src/lib/model/NormalAccessor.ts
+++ b/src/lib/model/NormalAccessor.ts
@@ -22,7 +22,7 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
     arg: Arg,
     action: NormalAction<S, Arg, Data>,
     updateState: (cb: (draft: Draft<S>) => void) => void,
-    getState: () => S,
+    getState: (serverStateKey?: object) => S,
     modelSubscribe: ModelSubscribe,
     notifyModel: () => void
   ) {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2,6 +2,7 @@ export * from './getCurrentTime';
 export * from './isNonNullable';
 export * from './isNull';
 export * from './isNumber';
+export * from './isServer';
 export * from './isString';
 export * from './isUndefined';
 export * from './noop';

--- a/src/lib/utils/isServer.ts
+++ b/src/lib/utils/isServer.ts
@@ -1,0 +1,3 @@
+export function isServer() {
+  return typeof window === 'undefined';
+}


### PR DESCRIPTION
## Proposed change

Use `ServerStateKeyProvider` to let developers update the server state but don't cause state pollution.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Testing
- [ ] Refactor
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

## Related Issue

#16 
